### PR TITLE
Update widget.js to not assume/depend on django-grapelli for its jquery

### DIFF
--- a/ace_overlay/static/ace_overlay/widget.js
+++ b/ace_overlay/static/ace_overlay/widget.js
@@ -1,7 +1,11 @@
 (function() {
-    
-    $ = grp.jQuery;
 
+    // Try to use django-grapelli's jQuery, else fall back to the Django admin's one 
+    try{
+        $ = grp.jQuery;
+    }catch(err){
+        $ = django.jQuery;
+    }
     function next(elem) {
         // Credit to John Resig for this function
         // taken from Pro JavaScript techniques


### PR DESCRIPTION
Try to use grapelli's jQ, else fall back to the version included by the django-admin

Addresses #1
