### PR TITLE
Make 'beautify' button work when there is more than one field.

### DIFF
--- a/ace_overlay/static/ace_overlay/widget.js
+++ b/ace_overlay/static/ace_overlay/widget.js
@@ -123,7 +123,7 @@
 
         $(".ace-overlay .beautify").bind("click", function (event) {
             event.preventDefault();
-            var overlay_container = $('.ace-overlay').find('.overlay-container');
+            var overlay_container = $(event.target).parents('.overlay-container');
             var editor = ace.edit($(overlay_container).find(".django-ace-widget")[0]);
             var text = editor.session.getValue();
             try {


### PR DESCRIPTION
I have a django model called Account with two JSON fields.

```
class Account(django_mysql.models.Model):
...
fields_mapping = JSONField(blank=True, null=False)
dashboard_config = JSONField(blank=True, null=False)
...

```

```
@admin.register(models.Account)
class AccountAdmin(admin.ModelAdmin):
...
formfield_overrides = {
    JSONField: {'widget': AceOverlayWidget(mode='json', theme='textmate')},
}
...
```

The bug is: when I click the beautify button of the second field, the "beautify function" is applied to the first field.