### PR TITLE
Add "float: left" to .ace-overlay css.

### DIFF
--- a/ace_overlay/static/ace_overlay/widget.css
+++ b/ace_overlay/static/ace_overlay/widget.css
@@ -3,6 +3,7 @@
     -moz-box-sizing: border-box;
     box-sizing: border-box;
 
+    float: left;
     position: relative;
     min-height: 30px;
 


### PR DESCRIPTION
Add "float: left" to .ace-overlay css, so the textarea doesn't overlap the field label.

Before:
![before](https://user-images.githubusercontent.com/7932044/31270505-f638403c-aa84-11e7-9ba2-ec826792ef7b.png)

After:
![after](https://user-images.githubusercontent.com/7932044/31270511-f918dbcc-aa84-11e7-99cc-7d48a6320406.png)
